### PR TITLE
Use hostname fqdn

### DIFF
--- a/nova_lxd/nova/virt/lxd/host.py
+++ b/nova_lxd/nova/virt/lxd/host.py
@@ -29,6 +29,7 @@ import os
 import platform
 from pylxd import api
 from pylxd import exceptions as lxd_exceptions
+import socket
 
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -69,7 +70,7 @@ class LXDHost(object):
             'hypervisor_type': 'lxd',
             'hypervisor_version': '011',
             'cpu_info': jsonutils.dumps(local_cpu_info),
-            'hypervisor_hostname': platform.node(),
+            'hypervisor_hostname': socket.getfqdn(),
             'supported_instances': jsonutils.dumps(
                 [(arch.I686, hv_type.LXC, vm_mode.EXE),
                     (arch.X86_64, hv_type.LXC, vm_mode.EXE)]),

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -498,7 +498,7 @@ class LXDTestDriver(test.NoDBTestCase):
             self.assertTrue(container_move)
             self.assertTrue(container_destroy)
 
-    @mock.patch('platform.node', mock.Mock(return_value='fake_hostname'))
+    @mock.patch('socket.getfqdn', mock.Mock(return_value='fake_hostname'))
     @mock.patch('os.statvfs', return_value=mock.Mock(f_blocks=131072000,
                                                      f_bsize=8192,
                                                      f_bavail=65536000))


### PR DESCRIPTION
Use socket.getfqdn() to return the FQDN hostname.
Fixes issue #77.

Signed-off-by: Chuck Short <chuck.short@canonical.com>