### PR TITLE
Use socket.gethostname()

### DIFF
--- a/nova_lxd/nova/virt/lxd/host.py
+++ b/nova_lxd/nova/virt/lxd/host.py
@@ -70,7 +70,7 @@ class LXDHost(object):
             'hypervisor_type': 'lxd',
             'hypervisor_version': '011',
             'cpu_info': jsonutils.dumps(local_cpu_info),
-            'hypervisor_hostname': socket.getfqdn(),
+            'hypervisor_hostname': socket.gethostname(),
             'supported_instances': jsonutils.dumps(
                 [(arch.I686, hv_type.LXC, vm_mode.EXE),
                     (arch.X86_64, hv_type.LXC, vm_mode.EXE)]),

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -499,7 +499,7 @@ class LXDTestDriver(test.NoDBTestCase):
             self.assertTrue(container_move)
             self.assertTrue(container_destroy)
 
-    @mock.patch('socket.getfqdn', mock.Mock(return_value='fake_hostname'))
+    @mock.patch('socket.gethostname', mock.Mock(return_value='fake_hostname'))
     @mock.patch('os.statvfs', return_value=mock.Mock(f_blocks=131072000,
                                                      f_bsize=8192,
                                                      f_bavail=65536000))


### PR DESCRIPTION
If FQDN is not setup correctly, then compute is not able
to manage the node correctly.

Signed-off-by: Chuck Short <chuck.short@canonical.com>