### PR TITLE
Use LXD as hypervisor type

### DIFF
--- a/nova_lxd/nova/virt/lxd/host.py
+++ b/nova_lxd/nova/virt/lxd/host.py
@@ -73,7 +73,9 @@ class LXDHost(object):
             'hypervisor_hostname': socket.getfqdn(),
             'supported_instances': jsonutils.dumps(
                 [(arch.I686, hv_type.LXD, vm_mode.EXE),
-                    (arch.X86_64, hv_type.LXD, vm_mode.EXE)]),
+                    (arch.X86_64, hv_type.LXD, vm_mode.EXE),
+                    (arch.I686, hv_type.LXC, vm_mode.EXE),
+                    (arch.X86_64, hv_type.LXC, vm_mode.EXE)]),
             'numa_topology': None,
         }
 

--- a/nova_lxd/nova/virt/lxd/host.py
+++ b/nova_lxd/nova/virt/lxd/host.py
@@ -72,8 +72,8 @@ class LXDHost(object):
             'cpu_info': jsonutils.dumps(local_cpu_info),
             'hypervisor_hostname': socket.getfqdn(),
             'supported_instances': jsonutils.dumps(
-                [(arch.I686, hv_type.LXC, vm_mode.EXE),
-                    (arch.X86_64, hv_type.LXC, vm_mode.EXE)]),
+                [(arch.I686, hv_type.LXD, vm_mode.EXE),
+                    (arch.X86_64, hv_type.LXD, vm_mode.EXE)]),
             'numa_topology': None,
         }
 

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -547,6 +547,10 @@ class LXDTestDriver(test.NoDBTestCase):
                     'supported_instances': [[arch.I686, hv_type.LXD,
                                              vm_mode.EXE],
                                             [arch.X86_64, hv_type.LXD,
+                                             vm_mode.EXE],
+                                            [arch.I686, hv_type.LXC,
+                                             vm_mode.EXE],
+                                            [arch.X86_64, hv_type.LXC,
                                              vm_mode.EXE]],
                     'vcpus': 200,
                     'vcpus_used': 0}

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -544,9 +544,9 @@ class LXDTestDriver(test.NoDBTestCase):
                     'memory_mb': 10000,
                     'memory_mb_used': 8000,
                     'numa_topology': None,
-                    'supported_instances': [[arch.I686, hv_type.LXC,
+                    'supported_instances': [[arch.I686, hv_type.LXD,
                                              vm_mode.EXE],
-                                            [arch.X86_64, hv_type.LXC,
+                                            [arch.X86_64, hv_type.LXD,
                                              vm_mode.EXE]],
                     'vcpus': 200,
                     'vcpus_used': 0}


### PR DESCRIPTION
LXD is in nova's recognized hypervisor list,
so use it.

Signed-off-by: Chuck Short <chuck.short@canonical.com>