### PR TITLE
Check for container operation in iamge_upload

### DIFF
--- a/nova_lxd/nova/virt/lxd/session/image.py
+++ b/nova_lxd/nova/virt/lxd/session/image.py
@@ -97,7 +97,10 @@ class ImageMixin(object):
             client = self.get_session(instance.host)
             (state, data) = client.image_upload(data=data,
                                                 headers=headers)
-            self.operation_wait(data.get('operation'), instance)
+            # XXX - zulcss (Dec 8, 2015) - Work around for older
+            # versions of LXD.
+            if 'operation' in data:
+                self.operation_wait(data.get('operation'), instance)
         except lxd_exceptions.APIError as ex:
             msg = _('Failed to communicate with LXD API %(instance)s:'
                     '%(reason)s') % {'instance': instance.image_ref,


### PR DESCRIPTION
Previous versions of LXD (below 0.22) does not send
an operation id. So check to see if we have an operation id
before waiting for the image upload to finish.

Signed-off-by: Chuck Short <chuck.short@canonical.com>