### PR TITLE
Drop JSON encoding for supported_instances

### DIFF
--- a/nova_lxd/nova/virt/lxd/host.py
+++ b/nova_lxd/nova/virt/lxd/host.py
@@ -71,11 +71,11 @@ class LXDHost(object):
             'hypervisor_version': '011',
             'cpu_info': jsonutils.dumps(local_cpu_info),
             'hypervisor_hostname': socket.gethostname(),
-            'supported_instances': jsonutils.dumps(
+            'supported_instances':
                 [(arch.I686, hv_type.LXD, vm_mode.EXE),
                     (arch.X86_64, hv_type.LXD, vm_mode.EXE),
                     (arch.I686, hv_type.LXC, vm_mode.EXE),
-                    (arch.X86_64, hv_type.LXC, vm_mode.EXE)]),
+                    (arch.X86_64, hv_type.LXC, vm_mode.EXE)],
             'numa_topology': None,
         }
 

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -343,14 +343,21 @@ class LXDTestDriver(test.NoDBTestCase):
         ]
         value = self.connection.get_available_resource(None)
         value['cpu_info'] = json.loads(value['cpu_info'])
-        value['supported_instances'] = json.loads(value['supported_instances'])
-        expected = {'cpu_info': {'arch': platform.uname()[5],
-                                 'features': 'fake flag goes here',
-                                 'model': 'Fake CPU',
-                                 'topology': {'cores': '5',
-                                              'sockets': '10',
-                                              'threads': '4'},
-                                 'vendor': 'FakeVendor'},
+        value['supported_instances'] = [[arch.I686, hv_type.LXD,
+                                             vm_mode.EXE],
+                                        [arch.X86_64, hv_type.LXD,
+                                             vm_mode.EXE],
+                                        [arch.I686, hv_type.LXC,
+                                             vm_mode.EXE],
+                                        [arch.X86_64, hv_type.LXC,
+                                             vm_mode.EXE]]
+        expected = {'cpu_info': {u'arch': platform.uname()[5],
+                                 u'features': u'fake flag goes here',
+                                 u'model': u'Fake CPU',
+                                 u'topology': {u'cores': u'5',
+                                              u'sockets': u'10',
+                                              u'threads': u'4'},
+                                 u'vendor': u'FakeVendor'},
                     'hypervisor_hostname': 'fake_hostname',
                     'hypervisor_type': 'lxd',
                     'hypervisor_version': '011',

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -344,19 +344,19 @@ class LXDTestDriver(test.NoDBTestCase):
         value = self.connection.get_available_resource(None)
         value['cpu_info'] = json.loads(value['cpu_info'])
         value['supported_instances'] = [[arch.I686, hv_type.LXD,
-                                             vm_mode.EXE],
+                                         vm_mode.EXE],
                                         [arch.X86_64, hv_type.LXD,
-                                             vm_mode.EXE],
+                                         vm_mode.EXE],
                                         [arch.I686, hv_type.LXC,
-                                             vm_mode.EXE],
+                                         vm_mode.EXE],
                                         [arch.X86_64, hv_type.LXC,
-                                             vm_mode.EXE]]
+                                         vm_mode.EXE]]
         expected = {'cpu_info': {u'arch': platform.uname()[5],
                                  u'features': u'fake flag goes here',
                                  u'model': u'Fake CPU',
                                  u'topology': {u'cores': u'5',
-                                              u'sockets': u'10',
-                                              u'threads': u'4'},
+                                               u'sockets': u'10',
+                                               u'threads': u'4'},
                                  u'vendor': u'FakeVendor'},
                     'hypervisor_hostname': 'fake_hostname',
                     'hypervisor_type': 'lxd',


### PR DESCRIPTION
JSON encoding for supported_instances in the virt
drivers was a temporary measure that is not needed.
The encoding has been removed for all in tree virt
drivers. This patch removes the code that checks
for JSON encoding in the compute node object.

Apart of blueprint mitaka-objects