### PR TITLE
Check for LXD block devices

### DIFF
--- a/nova_lxd/nova/virt/lxd/config.py
+++ b/nova_lxd/nova/virt/lxd/config.py
@@ -104,11 +104,7 @@ class LXDContainerConfig(object):
             config['config'] = self.create_config(instance_name, instance)
 
             # Restrict the size of the "/" disk
-            lxd_config = self.session.get_host_config(instance)
-            if str(lxd_config['storage']) in ['btrfs', 'zfs']:
-                config['devices'] = self.configure_container_root(instance)
-            else:
-                config['devices'] = {}
+            config['devices'] = self.configure_container_root(instance)
 
             if network_info:
                 config['devices'].update(self.create_network(instance_name,
@@ -187,10 +183,14 @@ class LXDContainerConfig(object):
                   instance=instance)
         try:
             config = {}
-            config['root'] = {'path': '/',
-                              'type': 'disk',
-                              'size': '%sGB' % str(instance.root_gb)
-                              }
+            lxd_config = self.session.get_host_config(instance)
+            if str(lxd_config['storage']) in ['btrfs', 'zfs']:
+                config['root'] = {'path': '/',
+                                  'type': 'disk',
+                                  'size': '%sGB' % str(instance.root_gb)}
+            else:
+                config['root'] = {'path': '/',
+                                  'type': 'disk'}
             return config
         except Exception as ex:
             with excutils.save_and_reraise_exception():

--- a/nova_lxd/nova/virt/lxd/config.py
+++ b/nova_lxd/nova/virt/lxd/config.py
@@ -104,7 +104,7 @@ class LXDContainerConfig(object):
             config['config'] = self.create_config(instance_name, instance)
 
             # Restrict the size of the "/" disk
-            lxd_config = self.session.host_config(instance)
+            lxd_config = self.session.get_host_config(instance)
             if str(lxd_config['storage']) in ['btrfs', 'zfs']:
                 config['devices'] = self.configure_container_root(instance)
             else:

--- a/nova_lxd/nova/virt/lxd/config.py
+++ b/nova_lxd/nova/virt/lxd/config.py
@@ -104,7 +104,11 @@ class LXDContainerConfig(object):
             config['config'] = self.create_config(instance_name, instance)
 
             # Restrict the size of the "/" disk
-            config['devices'] = self.configure_container_root(instance)
+            lxd_config = self.session.host_config(instance)
+            if str(lxd_config['storage']) in ['btrfs', 'zfs']:
+                config['devices'] = self.configure_container_root(instance)
+            else:
+                config['devices'] = {}
 
             if network_info:
                 config['devices'].update(self.create_network(instance_name,

--- a/nova_lxd/nova/virt/lxd/session.py
+++ b/nova_lxd/nova/virt/lxd/session.py
@@ -811,6 +811,17 @@ class LXDAPISession(object):
                                       'ex': ex}
             LOG.error(msg)
 
+    def host_config(self, instance):
+        LOG.debug('host_config called for instance', instance=instance)
+        try:
+            client = self.get_session()
+            return client.host_config()['environment']
+        except lxd_exceptions.APIError as ex:
+            msg = _('Failed to communicate with LXD %(instance)s:'
+                    ' %(reason)s') % {'instance': instance.name,
+                                      'ex': ex}
+            LOG.error(msg)
+
     #
     # Migrate methods
     #

--- a/nova_lxd/nova/virt/lxd/session.py
+++ b/nova_lxd/nova/virt/lxd/session.py
@@ -811,7 +811,7 @@ class LXDAPISession(object):
                                       'ex': ex}
             LOG.error(msg)
 
-    def host_config(self, instance):
+    def get_host_config(self, instance):
         LOG.debug('host_config called for instance', instance=instance)
         try:
             client = self.get_session()

--- a/nova_lxd/tests/test_config.py
+++ b/nova_lxd/tests/test_config.py
@@ -112,7 +112,7 @@ class LXDTestContainerConfig(test.NoDBTestCase):
 
     @mock.patch.object(session.LXDAPISession, 'get_host_config',
                        mock.Mock(return_value={'storage': 'lvm'}))
-    def test_container_root_zfs(self):
+    def test_container_root_lvm(self):
         instance = stubs._fake_instance()
         config = self.config.configure_container_root(instance)
         self.assertEqual({'root': {'path': '/',

--- a/nova_lxd/tests/test_config.py
+++ b/nova_lxd/tests/test_config.py
@@ -20,6 +20,7 @@ from nova import test
 from nova.tests.unit import fake_network
 
 from nova_lxd.nova.virt.lxd import config
+from nova_lxd.nova.virt.lxd import session
 from nova_lxd.nova.virt.lxd import utils as container_dir
 from nova_lxd.tests import stubs
 
@@ -91,12 +92,31 @@ class LXDTestContainerConfig(test.NoDBTestCase):
         config = self.config.get_container_source(instance)
         self.assertEqual(config, {'type': 'image', 'alias': 'fake_image'})
 
-    def test_container_root(self):
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'btrfs'}))
+    def test_container_root_btrfs(self):
         instance = stubs._fake_instance()
         config = self.config.configure_container_root(instance)
         self.assertEqual({'root': {'path': '/',
                                    'type': 'disk',
                                    'size': '10GB'}}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'zfs'}))
+    def test_container_root_zfs(self):
+        instance = stubs._fake_instance()
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk',
+                                   'size': '10GB'}}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'lvm'}))
+    def test_container_root_zfs(self):
+        instance = stubs._fake_instance()
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk'}}, config)
 
     def test_container_nested_container(self):
         instance = stubs._fake_instance()


### PR DESCRIPTION
Check for LXD block device type before trying
to set the quota.

Signed-off-by: Chuck Short <chuck.short@canonical.com>