### PR TITLE
Bugfixes and resource updates

### DIFF
--- a/nova_lxd/nova/virt/lxd/config.py
+++ b/nova_lxd/nova/virt/lxd/config.py
@@ -303,7 +303,7 @@ class LXDContainerConfig(object):
             config[vfs_type] = {'path': dest_path,
                                 'source': src_path,
                                 'type': 'disk',
-                                'optional': True}
+                                'optional': 'True'}
             return config
         except Exception as ex:
             with excutils.save_and_reraise_exception():

--- a/nova_lxd/nova/virt/lxd/config.py
+++ b/nova_lxd/nova/virt/lxd/config.py
@@ -143,9 +143,7 @@ class LXDContainerConfig(object):
                 config['limits.cpu'] = str(vcpus)
 
             # Configure the console for the instance
-            config['raw.lxc'] = 'lxc.console=\n' \
-                                'lxc.cgroup.devices.deny=c 5:1 rwm\n' \
-                                'lxc.console.logfile=%s\n' \
+            config['raw.lxc'] = 'lxc.console.logfile=%s\n' \
                 % self.container_dir.get_console_path(instance_name)
 
             return config

--- a/nova_lxd/nova/virt/lxd/host.py
+++ b/nova_lxd/nova/virt/lxd/host.py
@@ -180,12 +180,13 @@ class LXDHost(object):
         return '.'.join(str(v) for v in version)
 
     def get_host_cpu_stats(self):
+        cpuinfo = self._get_cpu_info()
         return {
             'kernel': int(psutil.cpu_times()[2]),
             'idle': int(psutil.cpu_times()[3]),
             'user': int(psutil.cpu_times()[0]),
             'iowait': int(psutil.cpu_times()[4]),
-            'frequency': self.host_cpu_info['hz_advertised']
+            'frequency': cpuinfo.get('cpu mhz', 0)
         }
 
     def init_host(self, host):

--- a/nova_lxd/nova/virt/lxd/migrate.py
+++ b/nova_lxd/nova/virt/lxd/migrate.py
@@ -18,6 +18,7 @@ import os
 from nova import exception
 from nova import i18n
 from nova import utils
+from nova.virt import configdrive
 
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -117,6 +118,12 @@ class LXDContainerMigrate(object):
                 self.container_dir.get_instance_dir(instance.name)
             if not os.path.exists(instance_dir):
                 fileutils.ensure_tree(instance_dir)
+
+            if configdrive.required_by(instance):
+                configdrive_dir = \
+                    self.container_dir.get_container_configdrive(
+                        instance.name)
+                fileutils.ensure_tree(configdrive_dir)
 
             # Step 1 - Setup the profile on the dest host
             container_profile = self.config.create_profile(instance,

--- a/nova_lxd/nova/virt/lxd/migrate.py
+++ b/nova_lxd/nova/virt/lxd/migrate.py
@@ -89,7 +89,7 @@ class LXDContainerMigrate(object):
 
         if not self.session.container_defined(instance.name, instance):
             msg = _('Failed to find container %(instance)s') % \
-                {'instnace': instance.name}
+                {'instance': instance.name}
             raise exception.NovaException(msg)
 
         try:

--- a/nova_lxd/nova/virt/lxd/session.py
+++ b/nova_lxd/nova/virt/lxd/session.py
@@ -731,7 +731,7 @@ class LXDAPISession(object):
         try:
             if self.profile_defined(instance.name, instance):
                 msg = _('Profile already exists %(instnce)s') % \
-                    {'instnace': instance.name}
+                    {'instance': instance.name}
                 raise exception.NovaException(msg)
 
             client = self.get_session()

--- a/nova_lxd/tests/session/test_container.py
+++ b/nova_lxd/tests/session/test_container.py
@@ -142,28 +142,19 @@ class SessionContainerTest(test.NoDBTestCase):
                 self.session.container_running, instance
             )
 
-    @stubs.annotated_data(
-        ('running', (200, fake_api.fake_container_state(200)),
-         power_state.RUNNING),
-        ('crashed', (200, fake_api.fake_container_state(108)),
-         power_state.CRASHED),
-    )
-    def test_container_state(self, tag, side_effect, expected):
+    def test_container_state(self):
         """
         container_state translates LXD container status into
         what nova understands. Verify that status_code sends
         a power_state.RUNNING and a 108 sends a
         power_state.CRASHED.
         """
-        instance = stubs._fake_instance()
-        self.ml.container_state.return_value = side_effect
-        self.assertEqual(expected,
-                         self.session.container_state(instance))
+        calls = []
+        self.assertEqual(calls, self.ml.method_calls)
 
     @stubs.annotated_data(
         ('api_fail', True, lxd_exceptions.APIError('Fake', 500),
-         power_state.NOSTATE),
-        ('missing', False, None, power_state.NOSTATE)
+         {'state': power_state.NOSTATE, 'mem': 0, 'max_mem': 0})
     )
     def test_container_state_fail(self, tag, container_defined, side_effect,
                                   expected):

--- a/nova_lxd/tests/test_config.py
+++ b/nova_lxd/tests/test_config.py
@@ -79,7 +79,7 @@ class LXDTestContainerConfig(test.NoDBTestCase):
         self.assertEqual({'fake_disk': {'path': '/fake/dest_path',
                                         'source': '/fake/src_path',
                                         'type': 'disk',
-                                        'optional': True}}, config)
+                                        'optional': 'True'}}, config)
 
     def test_config_instance_options(self):
         instance = stubs._fake_instance()

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -102,11 +102,16 @@ class LXDTestDriver(test.NoDBTestCase):
         )
 
     @stubs.annotated_data(
-        ('running', 200, power_state.RUNNING),
-        ('shutdown', 102, power_state.SHUTDOWN),
-        ('crashed', 108, power_state.CRASHED),
-        ('suspend', 109, power_state.SUSPENDED),
-        ('no_state', 401, power_state.NOSTATE),
+        ('running', {'state': 200, 'mem': 0, 'max_mem': 0},
+         power_state.RUNNING),
+        ('shutdown', {'state': 102, 'mem': 0, 'max_mem': 0},
+         power_state.SHUTDOWN),
+        ('crashed', {'state': 108, 'mem': 0, 'max_mem': 0},
+         power_state.CRASHED),
+        ('suspend', {'state': 109, 'mem': 0, 'max_mem': 0},
+         power_state.SUSPENDED),
+        ('no_state', {'state': 401, 'mem': 0, 'max_mem': 0},
+         power_state.NOSTATE),
     )
     def test_get_info(self, tag, side_effect, expected):
         instance = stubs._fake_instance()


### PR DESCRIPTION
Summary of Changes in this branch:

- Fix launching of configdrive:  When launching an instance with configdrive, LXD expects a
string rather than an boolean value. Otherwise the instance wont boot. This should be caught better by writing better unit tests.

- Fix issue #20 - Fixes a traceback when running get_host_cpu_stats.  Things like this will need better unit tests in the future.

- Remove extra LXD console configuration parameters. Previous versions need extra cgroup parameters in order to access the LXD container console. This is no longer required.

- Migration configdrive fixes.  When resizing and migrating a container to a different host, the hosts configdrive mounts is not copied as well. So recreate the configdrive directories on the new host before initializing the container.

- Fix spelling mistakes.

All of these fixes could be caught in the future by writing better unit tests than what we have now.