### PR TITLE
Change location of console.log

### DIFF
--- a/nova_lxd/nova/virt/lxd/utils.py
+++ b/nova_lxd/nova/virt/lxd/utils.py
@@ -55,8 +55,7 @@ class LXDContainerDirectories(object):
                             'configdrive')
 
     def get_console_path(self, instance):
-        return os.path.join(CONF.lxd.root_dir,
-                            'containers',
+        return os.path.join('/var/log/lxd/',
                             instance,
                             'console.log')
 

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -252,7 +252,7 @@ class LXDTestDriver(test.NoDBTestCase):
                          self.connection.get_console_output({}, instance))
         calls = [
             mock.call('chown', '1234:1234',
-                      '/fake/lxd/root/containers/fake-uuid/console.log',
+                      '/var/log/lxd/fake-uuid/console.log',
                       run_as_root=True),
             mock.call('chmod', '755',
                       '/fake/lxd/root/containers/fake-uuid',


### PR DESCRIPTION
Currently the console for the instance is written to
'/var/lib/contianers/instance-xxx/console.log'. This prevents from
LVM based instances from being destroyed properly because the
file is still open.

Signed-off-by: Chuck Short <chuck.short@canonical.com>