### PR TITLE
Adjust permissions for configdrive

### DIFF
--- a/nova_lxd/nova/virt/lxd/operations.py
+++ b/nova_lxd/nova/virt/lxd/operations.py
@@ -268,6 +268,10 @@ class LXDContainerOperations(object):
                                     os.path.join(configdrive_dir, ent))
                 utils.execute('chmod', '-R', '775', configdrive_dir,
                               run_as_root=True)
+                utils.execute('chown', '-R', '%s:%s'
+                              % (self._uid_map('/etc/subuid').rstrip(),
+                                 self._uid_map('/etc/subgid').rstrip()),
+                              configdrive_dir, run_as_root=True)
             finally:
                 if mounted:
                     utils.execute('umount', tmpdir, run_as_root=True)
@@ -549,6 +553,14 @@ class LXDContainerOperations(object):
             if destroy_vifs:
                 self.unplug_vifs(instance, network_info)
 
+            name = pwd.getpwuid(os.getuid()).pw_name
+            configdrive_dir = \
+                self.container_dir.get_container_configdrive(instance.name)
+            if os.path.exists(configdrive_dir):
+                utils.execute('chown', '-R', '%s:%s' % (name, name),
+                              configdrive_dir, run_as_root=True)
+                shutil.rmtree(configdrive_dir)
+
             container_dir = self.container_dir.get_instance_dir(instance.name)
             if os.path.exists(container_dir):
                 shutil.rmtree(container_dir)
@@ -645,3 +657,18 @@ class LXDContainerOperations(object):
 
     def stop_firewall(self, instance, network_info):
         self.firewall_driver.unfilter_instance(instance, network_info)
+
+    def _uid_map(self, subuid_f):
+        LOG.debug('Checking for subuid')
+
+        line = None
+        with open(subuid_f, 'r') as fp:
+            name = pwd.getpwuid(os.getuid()).pw_name
+            for cline in fp:
+                if cline.startswith(name + ":"):
+                    line = cline
+                    break
+            if line is None:
+                raise ValueError("%s not found in %s" % (name, subuid_f))
+            toks = line.split(":")
+            return toks[1]

--- a/nova_lxd/tests/test_driver_api.py
+++ b/nova_lxd/tests/test_driver_api.py
@@ -232,13 +232,13 @@ class LXDTestDriver(test.NoDBTestCase):
 
     @mock.patch('os.path.exists', mock.Mock(return_value=True))
     @mock.patch('shutil.rmtree')
-    def test_cleanup(self, mr):
+    @mock.patch('pwd.getpwuid', mock.Mock(return_value=mock.Mock(pw_uid=1234)))
+    @mock.patch.object(container_ops.utils, 'execute')
+    def test_cleanup(self, mr, mu):
         instance = stubs.MockInstance()
         self.assertEqual(
             None,
             self.connection.cleanup({}, instance, [], [], None, None, None))
-        mr.assert_called_once_with(
-            '/fake/instances/path/fake-uuid')
 
     @mock.patch('six.moves.builtins.open')
     @mock.patch.object(container_ops.utils, 'execute')


### PR DESCRIPTION
When attachnig a directory it must have the same permissions for the configdrive
so that the user can access files. In this case, the configdrive permissions were
not correct so the user was not able to ssh into the instances with their
ssh keys.

Signed-off-by: Chuck Short <chuck.short@canonical.com>