### PR TITLE
Move test-requirements to tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "3.4"
   - "2.7"
 install: pip install -U -r requirements.txt -r test-requirements.txt \
-         -egit+https://github.com/lxc/pylxd#egg=pylxd \
-         -git+https://github.com/openstack/nova#egg=nova
+         -e git+https://github.com/lxc/pylxd#egg=pylxd \
+         -e git+https://github.com/openstack/nova#egg=nova
 before_script: flake8 --ignore=E123,E125,H904,H405,H404,H305,H306,H307
 script: ostestr
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: python
 python:
   - "3.4"
   - "2.7"
-install: pip install -U -r requirements.txt -r test-requirements.txt \
-         -e git+https://github.com/lxc/pylxd#egg=pylxd \
-         -e git+https://github.com/openstack/nova#egg=nova
+install: pip install -U -r requirements.txt -r test-requirements.txt git+https://github.com/lxc/pylxd#egg=pylxd git+https://github.com/openstack/nova#egg=nova
 before_script: flake8 --ignore=E123,E125,H904,H405,H404,H305,H306,H307
 script: ostestr
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - "3.4"
   - "2.7"
-install: pip install -U -r requirements.txt -r test-requirements.txt
+install: pip install -U -r requirements.txt -r test-requirements.txt \
+         -egit+https://github.com/lxc/pylxd#egg=pylxd \
+         -git+https://github.com/openstack/nova#egg=nova
 before_script: flake8 --ignore=E123,E125,H904,H405,H404,H305,H306,H307
 script: ostestr
 cache:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,5 +16,3 @@ testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=1.4.0 # MIT
 os-testr>=0.4.1 # Apache-2.0
 nosexcover # BSD
--e git+https://github.com/lxc/pylxd#egg=pylxd
--e git+https://github.com/openstack/nova#egg=nova

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ setenv =
    PYTHONDONTWRITEBYTECODE=1
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+       -egit+https://github.com/lxc/pylxd#egg=pylxd
+       -egit+https://github.com/openstack/nova#egg=nova
 commands = ostestr {posargs}
 
 [testenv:pep8]


### PR DESCRIPTION
It was preventing devstack from installing correctly.

Signed-off-by: Chuck Short <chuck.short@canonical.com>