### PR TITLE
importable Glance metadata definition file

### DIFF
--- a/contrib/glance_metadefs/compute-lxd-flavor.json
+++ b/contrib/glance_metadefs/compute-lxd-flavor.json
@@ -1,0 +1,26 @@
+{
+    "namespace": "OS::Nova::LXDFlavor",
+    "display_name": "LXD properties",
+    "description": "You can pass several options to the LXD container hypervisor that will affect the container's capabilities.",
+    "visibility": "public",
+    "protected": false,
+    "resource_type_associations": [
+        {
+            "name": "OS::Nova::Flavor"
+        }
+    ],
+    "properties": {
+        "lxd:nested_allowed": {
+            "title": "Allow nested containers",
+            "description": "Allow or disallow creation of nested containers. If True, you can install and run LXD inside the VM itself and provision another level of containers.",
+            "type": "string",
+            "default": false
+        },
+        "lxd:privileged_allowed": {
+            "title": "Create privileged container",
+            "description": "Containers created as Privileged have elevated powers on the compute host. You should not set this option on containers that you don't fully trust.",
+            "type": "string",
+            "default": false
+        }
+    }
+}


### PR DESCRIPTION
The importable Glance metadefs are not only a convenient way to pass metadata from Horizon; they also help in documenting the project's metadata namespace. This metadata definition exposes the "lxd:nested_allowed" and "lxd:privileged_allowed" properties to flavors.