### PR TITLE
No python 3.4 on xenial

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 1.6
 # Python 3 tests MUST run first, due to this bug:
 # https://bugs.launchpad.net/testrepository/+bug/1229445
-envlist = py34,py27,pep8
+envlist = py3,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
A generic python 3 will suffice.