### PR TITLE
Sync with compute driver

### DIFF
--- a/nova/tests/unit/virt/lxd/test_driver_api.py
+++ b/nova/tests/unit/virt/lxd/test_driver_api.py
@@ -73,6 +73,8 @@ class LXDTestDriver(test.NoDBTestCase):
         self.assertFalse(self.connection.capabilities['supports_recreate'])
         self.assertFalse(
             self.connection.capabilities['supports_migrate_to_same_host'])
+        self.assertTrue(
+            self.connection.capabilities['supports_attach_interface'])
 
     def test_init_host(self):
         self.assertEqual(

--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -60,6 +60,7 @@ class LXDDriver(driver.ComputeDriver):
         "has_imagecache": False,
         "supports_recreate": False,
         "supports_migrate_to_same_host": False,
+        "supports_attach_interface": True
     }
 
     def __init__(self, virtapi):


### PR DESCRIPTION
Add check for driver compatibility for 'supports_attach_interface'.

Signed-off-by: Chuck Short <chuck.short@canonical.com>