### PR TITLE
Disk and NIC quotas

### DIFF
--- a/nova/tests/unit/virt/lxd/test_config.py
+++ b/nova/tests/unit/virt/lxd/test_config.py
@@ -235,10 +235,10 @@ class LXDTestContainerConfig(test.NoDBTestCase):
         # Max of the two values should take precedence
         instance = stubs._fake_instance()
         instance.flavor.extra_specs = {
-            'quota:vif_inbound_average': 20 * units.M,
-            'quota:vif_outbound_average': 9 * units.M,
-            'quota:vif_inbound_peak': 21 * units.M,
-            'quota:vif_outbound_peak': 8 * units.M,
+            'quota:vif_inbound_average': 2 * units.M,
+            'quota:vif_outbound_average': 10 * units.M,
+            'quota:vif_inbound_peak': 10 * units.M,
+            'quota:vif_outbound_peak': 2 * units.M,
         }
         instance_name = 'fake_instance'
         network_info = fake_network.fake_get_instance_nw_info(self)
@@ -248,5 +248,5 @@ class LXDTestContainerConfig(test.NoDBTestCase):
                                        'nictype': 'bridged',
                                        'parent': 'fake_br1',
                                        'type': 'nic',
-                                       'limits.ingress': '21Mbit',
-                                       'limits.egress': '9Mbit'}}, config)
+                                       'limits.ingress': '10Mbit',
+                                       'limits.egress': '10Mbit'}}, config)

--- a/nova/tests/unit/virt/lxd/test_config.py
+++ b/nova/tests/unit/virt/lxd/test_config.py
@@ -22,6 +22,8 @@ from nova.tests.unit import fake_network
 from nova.virt.lxd import config
 from nova.virt.lxd import session
 from nova.virt.lxd import utils as container_dir
+from oslo_utils import units
+
 import stubs
 
 
@@ -132,3 +134,119 @@ class LXDTestContainerConfig(test.NoDBTestCase):
         config = self.config.config_instance_options({}, instance)
         self.assertEqual({'security.privileged': 'True',
                           'boot.autostart': 'True'}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'zfs'}))
+    def test_disk_quota_rw_iops(self):
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {'quota:disk_read_iops_sec': 10000,
+                                       'quota:disk_write_iops_sec': 10000}
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk',
+                                   'size': '10GB',
+                                   'limits.read': '10000iops',
+                                   'limits.write': '10000iops'}}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'zfs'}))
+    def test_disk_quota_rw_iops_and_bytes(self):
+        # Byte values should take precedence
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {
+            'quota:disk_read_iops_sec': 10000,
+            'quota:disk_write_iops_sec': 10000,
+            'quota:disk_read_bytes_sec': 13 * units.Mi,
+            'quota:disk_write_bytes_sec': 5 * units.Mi
+        }
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk',
+                                   'size': '10GB',
+                                   'limits.read': '13MB',
+                                   'limits.write': '5MB'}}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'zfs'}))
+    def test_disk_quota_total_iops(self):
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {
+            'quota:disk_total_iops_sec': 10000
+        }
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk',
+                                   'size': '10GB',
+                                   'limits.max': '10000iops'}}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'zfs'}))
+    def test_disk_quota_total_iops_and_bytes(self):
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {
+            'quota:disk_total_iops_sec': 10000,
+            'quota:disk_total_bytes_sec': 11 * units.Mi
+        }
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk',
+                                   'size': '10GB',
+                                   'limits.max': '11MB'}}, config)
+
+    @mock.patch.object(session.LXDAPISession, 'get_host_config',
+                       mock.Mock(return_value={'storage': 'zfs'}))
+    def test_disk_quota_rw_and_total_iops_and_bytes(self):
+        # More granular quotas should be set only, moreover
+        # in MBytes, not iops
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {
+            'quota:disk_read_iops_sec': 10000,
+            'quota:disk_write_iops_sec': 10000,
+            'quota:disk_read_bytes_sec': 13 * units.Mi,
+            'quota:disk_write_bytes_sec': 5 * units.Mi,
+            'quota:disk_total_iops_sec': 10000,
+            'quota:disk_total_bytes_sec': 11 * units.Mi
+        }
+        config = self.config.configure_container_root(instance)
+        self.assertEqual({'root': {'path': '/',
+                                   'type': 'disk',
+                                   'size': '10GB',
+                                   'limits.read': '13MB',
+                                   'limits.write': '5MB'}}, config)
+
+    def test_network_in_out_average(self):
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {
+            'quota:vif_inbound_average': 20 * units.M,
+            'quota:vif_outbound_average': 8 * units.M
+        }
+        instance_name = 'fake_instance'
+        network_info = fake_network.fake_get_instance_nw_info(self)
+        config = self.config.create_network(instance_name, instance,
+                                            network_info)
+        self.assertEqual({'fake_br1': {'hwaddr': 'DE:AD:BE:EF:00:01',
+                                       'nictype': 'bridged',
+                                       'parent': 'fake_br1',
+                                       'type': 'nic',
+                                       'limits.ingress': '20Mbit',
+                                       'limits.egress': '8Mbit'}}, config)
+
+    def test_network_in_out_average_and_peak(self):
+        # Max of the two values should take precedence
+        instance = stubs._fake_instance()
+        instance.flavor.extra_specs = {
+            'quota:vif_inbound_average': 20 * units.M,
+            'quota:vif_outbound_average': 9 * units.M,
+            'quota:vif_inbound_peak': 21 * units.M,
+            'quota:vif_outbound_peak': 8 * units.M,
+        }
+        instance_name = 'fake_instance'
+        network_info = fake_network.fake_get_instance_nw_info(self)
+        config = self.config.create_network(instance_name, instance,
+                                            network_info)
+        self.assertEqual({'fake_br1': {'hwaddr': 'DE:AD:BE:EF:00:01',
+                                       'nictype': 'bridged',
+                                       'parent': 'fake_br1',
+                                       'type': 'nic',
+                                       'limits.ingress': '21Mbit',
+                                       'limits.egress': '9Mbit'}}, config)

--- a/nova/virt/lxd/config.py
+++ b/nova/virt/lxd/config.py
@@ -227,10 +227,15 @@ class LXDContainerConfig(object):
         if disk_write_bytes_sec:
             disk_config['limits.write'] = str(disk_write_bytes_sec / units.Mi) + 'MB'
 
-        if disk_total_iops_sec:
+        # If at least one of the above limits has been defined, do not set
+        # the "max" quota (which would apply to both read and write)
+        minor_quota_defined = (disk_read_iops_sec or disk_write_iops_sec or
+                               disk_read_bytes_sec or disk_write_bytes_sec)
+
+        if disk_total_iops_sec and not minor_quota_defined:
             disk_config['limits.max'] = str(disk_total_iops_sec) + 'iops'
 
-        if disk_total_bytes_sec:
+        if disk_total_bytes_sec and not minor_quota_defined:
             disk_config['limits.max'] = str(disk_total_bytes_sec / units.Mi) + 'MB'
 
         return disk_config


### PR DESCRIPTION
The OS::Compute::Quota metadata namespace defines Disk, NIC and CPU quotas that are passed to the hypervisor (currently only Libvirt) via flavor metadata. This PR implements just two of them - NIC and Disk - because I didn't find a way to sensibly translate the CPU quota parameters to the LXD world.

However, the Disk and NIC quotas are fairly well understood by LXD and allow us to control container throughput to disks or network in Bytes/s or IOps.