### PR TITLE
Transition to nova.conf

### DIFF
--- a/nova/tests/unit/virt/lxd/test_driver_api.py
+++ b/nova/tests/unit/virt/lxd/test_driver_api.py
@@ -21,8 +21,9 @@ from pylxd.deprecated import exceptions as lxd_exceptions
 
 import ddt
 import mock
-from oslo_config import cfg
 import six
+
+from oslo_config import cfg
 
 from nova.compute import arch
 from nova.compute import hv_type

--- a/nova/virt/lxd/container_firewall.py
+++ b/nova/virt/lxd/container_firewall.py
@@ -13,12 +13,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import nova.conf
 from nova.virt import firewall
 
-from oslo_config import cfg
 from oslo_log import log as logging
 
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
 
 

--- a/nova/virt/lxd/container_snapshot.py
+++ b/nova/virt/lxd/container_snapshot.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.from oslo_config import cfg
 
+import nova.conf
 from nova.compute import task_states
 from nova import exception
 from nova import i18n
@@ -21,7 +22,6 @@ from nova import image
 import os
 
 from oslo_concurrency import lockutils
-from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import excutils
 
@@ -30,7 +30,7 @@ from nova.virt.lxd import session
 _ = i18n._
 _LE = i18n._LE
 
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
 
 IMAGE_API = image.API()

--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 
-import nova.conf
 from nova import exception
 from nova import i18n
 from nova.virt import driver

--- a/nova/virt/lxd/driver.py
+++ b/nova/virt/lxd/driver.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 
+import nova.conf
 from nova import exception
 from nova import i18n
 from nova.virt import driver

--- a/nova/virt/lxd/host.py
+++ b/nova/virt/lxd/host.py
@@ -18,6 +18,7 @@
 #    under the License.
 
 
+import nova.conf
 from nova.compute import arch
 from nova.compute import hv_type
 from nova.compute import utils as compute_utils
@@ -31,7 +32,6 @@ from pylxd.deprecated import api
 from pylxd.deprecated import exceptions as lxd_exceptions
 import socket
 
-from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 from oslo_utils import units
@@ -39,7 +39,7 @@ import psutil
 
 _ = i18n._
 _LW = i18n._LW
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
 
 

--- a/nova/virt/lxd/image.py
+++ b/nova/virt/lxd/image.py
@@ -16,6 +16,7 @@
 import hashlib
 import io
 import json
+import nova.conf
 from nova.compute import arch
 from nova import exception
 from nova import i18n
@@ -29,7 +30,6 @@ import uuid
 
 from oslo_concurrency import lockutils
 from oslo_concurrency import processutils
-from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import fileutils
@@ -40,7 +40,7 @@ from nova.virt.lxd import utils as container_dir
 _ = i18n._
 _LE = i18n._LE
 
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
 IMAGE_API = image.API()
 

--- a/nova/virt/lxd/operations.py
+++ b/nova/virt/lxd/operations.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 
+import nova.conf
 from nova.api.metadata import base as instance_metadata
 from nova.virt import configdrive
 from nova.virt import hardware
@@ -22,7 +23,6 @@ import os
 import pwd
 import shutil
 
-from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import fileutils
@@ -45,7 +45,7 @@ _LE = i18n._LE
 _LW = i18n._LW
 _LI = i18n._LI
 
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 CONF.import_opt('vif_plugging_timeout', 'nova.virt.driver')
 CONF.import_opt('vif_plugging_is_fatal', 'nova.virt.driver')
 LOG = logging.getLogger(__name__)

--- a/nova/virt/lxd/utils.py
+++ b/nova/virt/lxd/utils.py
@@ -15,9 +15,9 @@
 
 import os
 
-from oslo_config import cfg
+import nova.conf
 
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 
 
 class LXDContainerDirectories(object):

--- a/nova/virt/lxd/vif.py
+++ b/nova/virt/lxd/vif.py
@@ -13,9 +13,9 @@
 #    under the License.
 
 from oslo_concurrency import processutils
-from oslo_config import cfg
 from oslo_log import log as logging
 
+import nova.conf
 from nova import exception
 from nova import i18n
 from nova.network import linux_net
@@ -25,7 +25,7 @@ from nova import utils
 _ = i18n._
 _LE = i18n._LE
 
-CONF = cfg.CONF
+CONF = nova.conf.CONF
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
In the mitaka cycle, nova.conf has centralized all
the Nova configuration options in one place. Transition
nova-lxd to use nova.conf to access configuration
options.

Signed-off-by: Chuck Short <chuck.short@canonical.com>