### PR TITLE
fixed unit conversions in network quotas

### DIFF
--- a/nova/tests/unit/virt/lxd/test_config.py
+++ b/nova/tests/unit/virt/lxd/test_config.py
@@ -216,9 +216,11 @@ class LXDTestContainerConfig(test.NoDBTestCase):
 
     def test_network_in_out_average(self):
         instance = stubs._fake_instance()
+        # We get KB/s from flavor spec, but expect Mbit/s
+        # in LXD confix
         instance.flavor.extra_specs = {
-            'quota:vif_inbound_average': 20 * units.M,
-            'quota:vif_outbound_average': 8 * units.M
+            'quota:vif_inbound_average': 20000,
+            'quota:vif_outbound_average': 8000
         }
         instance_name = 'fake_instance'
         network_info = fake_network.fake_get_instance_nw_info(self)
@@ -228,17 +230,17 @@ class LXDTestContainerConfig(test.NoDBTestCase):
                                        'nictype': 'bridged',
                                        'parent': 'fake_br1',
                                        'type': 'nic',
-                                       'limits.ingress': '20Mbit',
-                                       'limits.egress': '8Mbit'}}, config)
+                                       'limits.ingress': '160Mbit',
+                                       'limits.egress': '64Mbit'}}, config)
 
     def test_network_in_out_average_and_peak(self):
         # Max of the two values should take precedence
         instance = stubs._fake_instance()
         instance.flavor.extra_specs = {
-            'quota:vif_inbound_average': 2 * units.M,
-            'quota:vif_outbound_average': 10 * units.M,
-            'quota:vif_inbound_peak': 10 * units.M,
-            'quota:vif_outbound_peak': 2 * units.M,
+            'quota:vif_inbound_average': 2000,
+            'quota:vif_outbound_average': 10000,
+            'quota:vif_inbound_peak': 10000,
+            'quota:vif_outbound_peak': 2000,
         }
         instance_name = 'fake_instance'
         network_info = fake_network.fake_get_instance_nw_info(self)
@@ -248,5 +250,5 @@ class LXDTestContainerConfig(test.NoDBTestCase):
                                        'nictype': 'bridged',
                                        'parent': 'fake_br1',
                                        'type': 'nic',
-                                       'limits.ingress': '10Mbit',
-                                       'limits.egress': '10Mbit'}}, config)
+                                       'limits.ingress': '80Mbit',
+                                       'limits.egress': '80Mbit'}}, config)

--- a/nova/virt/lxd/config.py
+++ b/nova/virt/lxd/config.py
@@ -310,14 +310,15 @@ class LXDContainerConfig(object):
         # Since LXD does not implement average NIC IO and number of burst
         # bytes, we take the max(vif_*_average, vif_*_peak) to set the peak
         # network IO and simply ignore the burst bytes.
-        # Align values to MB/s (powers of 1000 in this case)
+        # Align values to MBit/s (8 * powers of 1000 in this case), having
+        # in mind that the values are recieved in Kilobytes/s.
         vif_inbound_limit = max(
             q.get('vif_inbound_average'),
             q.get('vif_inbound_peak')
         )
         if vif_inbound_limit:
             network_config['limits.ingress'] = \
-                ('%s' + 'Mbit') % (vif_inbound_limit / units.M)
+                ('%s' + 'Mbit') % (vif_inbound_limit * units.k * 8 / units.M)
 
         vif_outbound_limit = max(
             q.get('vif_outbound_average'),
@@ -325,7 +326,7 @@ class LXDContainerConfig(object):
         )
         if vif_outbound_limit:
             network_config['limits.egress'] = \
-                ('%s' + 'Mbit') % (vif_outbound_limit / units.M)
+                ('%s' + 'Mbit') % (vif_outbound_limit * units.k * 8 / units.M)
 
         return network_config
 


### PR DESCRIPTION
Having done some practical tests, I came about an error in a previous commit. The compute quota metadata interface asks users to input network quotas in Kilobytes/s, while LXD expects *bits/s. So in the end we have to multiply user input by (8 * units.k).