### PR TITLE
Show actual error message when LXD API fails

### DIFF
--- a/nova/virt/lxd/session.py
+++ b/nova/virt/lxd/session.py
@@ -531,7 +531,8 @@ class LXDAPISession(object):
             status, data = self.operation_info(operation, instance)
             data = data.get('metadata')
             if not data['status_code'] == 200:
-                raise exception.NovaException(data['metadata'])
+                msg = data.get('err') or data['metadata']
+                raise exception.NovaException(msg)
 
             LOG.info(_LI('Successfully created container %(instance)s with'
                          ' %(image)s'), {'instance': instance.name,


### PR DESCRIPTION
When the LXD API returns an error during instance creation, the actual error message is passed in data['metadata']['err'], not data['metadata']['metadata'].
Even worse metadata might be empty, in which case Nova will only show "An unknown exception occured".

This change turned "An unknown exception occured" (even with highest debug logging) into "btrfs quotas not supported. Try enabling them with 'btrfs quota enable'.".

My fix is pretty rough, because I do not understand the reasoning behind the original code. In all my tests this field was empty, while 'err' contained the error message, but you never know.

(Also, line 532: Why is data.get('metadata') used instead of regular item access? If 'metadata' is not in data, the next line will fail anyway...)