### PR TITLE
Code tidyness

### DIFF
--- a/nova/tests/unit/virt/lxd/test_session.py
+++ b/nova/tests/unit/virt/lxd/test_session.py
@@ -84,17 +84,14 @@ class SessionContainerTest(test.NoDBTestCase):
         self.assertEqual((200, fake_api.fake_container_config()),
                          self.session.container_update(config, instance))
         calls = [
-            mock.call.container_defined(instance.name),
             mock.call.container_update(instance.name, config)]
         self.assertEqual(calls, self.ml.method_calls)
 
     @stubs.annotated_data(
-        ('api_fail', True, lxd_exceptions.APIError('Fake', 500),
+        ('api_fail', lxd_exceptions.APIError('Fake', 500),
          exception.NovaException),
-        ('missing_container', False, None,
-         exception.InstanceNotFound)
     )
-    def test_container_update_fail(self, tag, container_defined, side_effect,
+    def test_container_update_fail(self, tag, side_effect,
                                    expected):
         """
         container_update will fail if the container is not found, or the
@@ -103,18 +100,11 @@ class SessionContainerTest(test.NoDBTestCase):
         """
         config = mock.Mock()
         instance = stubs._fake_instance()
-        if container_defined:
-            self.ml.container_defined.return_value = container_defined
-            self.ml.container_update.side_effect = (
-                lxd_exceptions.APIError('Fake', 500))
-            self.assertRaises(
-                expected,
-                self.session.container_update, config, instance)
-        if not container_defined:
-            self.ml.container_defined.return_value = container_defined
-            self.assertRaises(
-                expected,
-                self.session.container_update, config, instance)
+        self.ml.container_update.side_effect = (
+            lxd_exceptions.APIError('Fake', 500))
+        self.assertRaises(
+            expected,
+            self.session.container_update, config, instance)
 
     @stubs.annotated_data(
         ('running', True),
@@ -266,44 +256,14 @@ class SessionContainerTest(test.NoDBTestCase):
         Verify that the correct pyLXD calls are made.
         """
         instance = stubs._fake_instance()
-        self.ml.container_defined.return_value = defined
         self.ml.container_start.return_value = side_effect
         self.assertEqual(None,
                          self.session.container_start(instance.name,
                                                       instance))
-        calls = [mock.call.container_defined(instance.name),
-                 mock.call.container_start(instance.name, -1),
+        calls = [mock.call.container_start(instance.name, -1),
                  mock.call.wait_container_operation(
             '/1.0/operation/1234', 200, -1)]
         self.assertEqual(calls, self.ml.method_calls)
-
-    @stubs.annotated_data(
-        ('container_missing', False,
-         exception.InstanceNotFound),
-        ('api_error', True,
-         exception.NovaException,
-         lxd_exceptions.APIError('Fake', 500)),
-    )
-    def test_container_start_fail(self, tag, container_defined,
-                                  expected, side_effect=None):
-        """
-        container_start starts a container on a given LXD host.
-        Veify that an exception.InstanceNotFound when the container
-        is not found on an LXD host. Raises an exception.NovaException
-        when there is an APIError.
-        """
-        instance = stubs._fake_instance()
-        if container_defined:
-            self.ml.container_defined.return_value = container_defined
-            self.ml.container_start.side_effect = side_effect
-            self.assertRaises(expected,
-                              self.session.container_start,
-                              instance.name, instance)
-        if not container_defined:
-            self.ml.container_defined.return_value = container_defined
-            self.assertRaises(expected,
-                              self.session.container_start, instance.name,
-                              instance)
 
     @stubs.annotated_data(
         ('1', (200, fake_api.fake_operation_info_ok()))
@@ -319,8 +279,7 @@ class SessionContainerTest(test.NoDBTestCase):
         self.assertEqual(None,
                          self.session.container_stop(instance.name,
                                                      instance))
-        calls = [mock.call.container_defined(instance.name),
-                 mock.call.container_stop(instance.name, -1),
+        calls = [mock.call.container_stop(instance.name, -1),
                  mock.call.wait_container_operation(
             '/1.0/operation/1234', 200, -1)]
         self.assertEqual(calls, self.ml.method_calls)
@@ -353,8 +312,7 @@ class SessionContainerTest(test.NoDBTestCase):
         self.ml.container_reboot.return_value = side_effect
         self.assertEqual(None,
                          self.session.container_reboot(instance))
-        calls = [mock.call.container_defined(instance.name),
-                 mock.call.container_reboot(instance.name, -1),
+        calls = [mock.call.container_reboot(instance.name, -1),
                  mock.call.wait_container_operation(
                      '/1.0/operation/1234', 200, -1)]
         self.assertEqual(calls, self.ml.method_calls)
@@ -375,38 +333,26 @@ class SessionContainerTest(test.NoDBTestCase):
                           self.session.container_reboot, instance)
 
     @stubs.annotated_data(
-        ('exists', True, (200, fake_api.fake_operation_info_ok())),
-        ('missing', False, (200, fake_api.fake_operation_info_ok()))
+        ('exists', (200, fake_api.fake_operation_info_ok())),
     )
-    def test_container_destroy(self, tag, container_defined, side_effect):
+    def test_container_destroy(self, tag, side_effect):
         """
         container_destroy delete a container from the LXD Host. Check
         that the approiate pylxd calls are made.
         """
         instance = stubs._fake_instance()
-        if container_defined:
-            self.ml.container_defined.return_value = container_defined
-            self.ml.container_stop.return_value = side_effect
-            self.ml.container_destroy.return_value = side_effect
-            self.assertEqual(None,
-                             self.session.container_destroy(instance.name,
-                                                            instance))
-            calls = [mock.call.container_defined(instance.name),
-                     mock.call.container_defined(instance.name),
-                     mock.call.container_stop(instance.name, -1),
-                     mock.call.wait_container_operation(
-                '/1.0/operation/1234', 200, -1),
+        self.ml.container_stop.return_value = side_effect
+        self.ml.container_destroy.return_value = side_effect
+        self.assertEqual(None,
+                         self.session.container_destroy(instance.name,
+                                                        instance))
+        calls = [mock.call.container_stop(instance.name, -1),
+                mock.call.wait_container_operation(
+                    '/1.0/operation/1234', 200, -1),
                 mock.call.container_destroy(instance.name),
                 mock.call.wait_container_operation(
                 '/1.0/operation/1234', 200, -1)]
-            self.assertEqual(calls, self.ml.method_calls)
-        if not container_defined:
-            self.ml.container_defined.return_value = container_defined
-            self.assertEqual(None,
-                             self.session.container_destroy(instance.name,
-                                                            instance))
-            calls = [mock.call.container_defined(instance.name)]
-            self.assertEqual(calls, self.ml.method_calls)
+        self.assertEqual(calls, self.ml.method_calls)
 
     @stubs.annotated_data(
         ('fail_to_stop', True, 'fail_stop',
@@ -429,7 +375,6 @@ class SessionContainerTest(test.NoDBTestCase):
                               self.session.container_destroy, instance.name,
                               instance)
         if test_type == 'fail_destroy':
-            self.ml.container_defined.return_value = container_defined
             self.ml.container_stop.return_value = \
                 (200, fake_api.fake_operation_info_ok())
             self.ml.container_destroy.side_effect = side_effect
@@ -488,7 +433,6 @@ class SessionContainerTest(test.NoDBTestCase):
                          self.session.container_unpause(instance.name,
                                                         instance))
         calls = [
-            mock.call.container_defined(instance.name),
             mock.call.container_resume(instance.name, -1),
             mock.call.wait_container_operation(
                 '/1.0/operation/1234', 200, -1)]

--- a/nova/tests/unit/virt/lxd/test_session.py
+++ b/nova/tests/unit/virt/lxd/test_session.py
@@ -347,11 +347,11 @@ class SessionContainerTest(test.NoDBTestCase):
                          self.session.container_destroy(instance.name,
                                                         instance))
         calls = [mock.call.container_stop(instance.name, -1),
-                mock.call.wait_container_operation(
-                    '/1.0/operation/1234', 200, -1),
-                mock.call.container_destroy(instance.name),
-                mock.call.wait_container_operation(
-                '/1.0/operation/1234', 200, -1)]
+                 mock.call.wait_container_operation(
+            '/1.0/operation/1234', 200, -1),
+            mock.call.container_destroy(instance.name),
+            mock.call.wait_container_operation(
+            '/1.0/operation/1234', 200, -1)]
         self.assertEqual(calls, self.ml.method_calls)
 
     @stubs.annotated_data(

--- a/nova/virt/lxd/operations.py
+++ b/nova/virt/lxd/operations.py
@@ -31,7 +31,6 @@ from oslo_utils import units
 from nova import exception
 from nova import i18n
 from nova import utils
-from nova.compute import power_state
 
 from nova.virt.lxd import config as container_config
 from nova.virt.lxd import container_firewall

--- a/nova/virt/lxd/operations.py
+++ b/nova/virt/lxd/operations.py
@@ -474,10 +474,6 @@ class LXDContainerOperations(object):
         """
         LOG.debug('rescue called for instance', instance=instance)
         try:
-            if not self.session.container_defined(instance.name, instance):
-                msg = _('Unable to find instance')
-                raise exception.NovaException(msg)
-
             # Step 1 - Stop the old container
             self.session.container_stop(instance.name, instance)
 
@@ -513,10 +509,6 @@ class LXDContainerOperations(object):
         """
         LOG.debug('unrescue called for instance', instance=instance)
         try:
-            if not self.session.container_defined(instance.name, instance):
-                msg = _('Unable to find instance')
-                raise exception.NovaException(msg)
-
             # Step 1 - Destory the rescue instance.
             self.session.container_destroy(instance.name,
                                            instance)
@@ -581,9 +573,6 @@ class LXDContainerOperations(object):
         """
         LOG.debug('get_info called for instance', instance=instance)
         try:
-            if not self.session.container_defined(instance.name, instance):
-                return hardware.InstanceInfo(state=power_state.NOSTATE)
-
             container_state = self.session.container_state(instance)
             return hardware.InstanceInfo(state=container_state['state'],
                                          max_mem_kb=container_state['max_mem'],

--- a/nova/virt/lxd/session.py
+++ b/nova/virt/lxd/session.py
@@ -40,26 +40,6 @@ _LI = i18n._LI
 CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
 
-
-def mount_filesystem(self, dev_path, dir_path):
-    try:
-        _out, err = utils.execute('mount',
-                                  '-t', 'ext4',
-                                  dev_path, dir_path, run_as_root=True)
-    except processutils.ProcessExecutionError as e:
-        err = six.text_type(e)
-    return err
-
-
-def umount_filesystem(self, dir_path):
-    try:
-        _out, err = utils.execute('umount',
-                                  dir_path, run_as_root=True)
-    except processutils.ProcessExecutionError as e:
-        err = six.text_type(e)
-    return err
-
-
 class LXDAPISession(object):
     """The session to invoke the LXD API session."""
 

--- a/nova/virt/lxd/session.py
+++ b/nova/virt/lxd/session.py
@@ -107,9 +107,6 @@ class LXDAPISession(object):
         LOG.debug('container_update called fo instance', instance=instance)
         try:
             client = self.get_session()
-            if not self.container_defined(instance.name, instance):
-                msg = _('Instance is not found: %s') % instance.name
-                raise exception.InstanceNotFound(msg)
 
             return client.container_update(instance.name,
                                            config)
@@ -161,8 +158,6 @@ class LXDAPISession(object):
             max_mem = 0
 
             client = self.get_session()
-            if not self.container_defined(instance.name, instance):
-                return
 
             (state, data) = client.container_state(instance.name)
             state = constants.LXD_POWER_STATES[data['metadata']['status_code']]
@@ -195,10 +190,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_config called for instance', instance=instance)
         try:
-            if not self.container_defined(instance.name, instance):
-                msg = _('Instance is not found %s') % instance.name
-                raise exception.InstanceNotFound(msg)
-
             client = self.get_session()
             return client.get_container_config(instance.name)
         except lxd_exceptions.APIError as ex:
@@ -222,10 +213,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_info called for instance', instance=instance)
         try:
-            if not self.container_defined(instance.name, instance):
-                msg = _('Instance is not found %s') % instance.name
-                raise exception.InstanceNotFound(msg)
-
             client = self.get_session()
             return client.container_info(instance.name)
         except lxd_exceptions.APIError as ex:
@@ -280,12 +267,6 @@ class LXDAPISession(object):
             # Start the container
             client = self.get_session()
 
-            # (chuck): Something wicked could happen between
-            # container
-            if not self.container_defined(instance_name, instance):
-                msg = _('Instance is not found %s ') % instance.name
-                raise exception.InstanceNotFound(msg)
-
             (state, data) = client.container_start(instance_name,
                                                    CONF.lxd.timeout)
             self.operation_wait(data.get('operation'), instance)
@@ -314,10 +295,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_stop called for instance', instance=instance)
         try:
-            if not self.container_defined(instance_name, instance):
-                msg = _('Instance is not found %s') % instance.name
-                raise exception.InstanceNotFound(msg)
-
             LOG.info(_LI('Stopping instance %(instance)s with'
                          ' %(image)s'), {'instance': instance.name,
                                          'image': instance.image_ref})
@@ -350,10 +327,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_reboot called for instance', instance=instance)
         try:
-            if not self.container_defined(instance.name, instance):
-                msg = _('Instance is not found %s') % instance.name
-                raise exception.InstanceNotFound(msg)
-
             LOG.info(_LI('Rebooting instance %(instance)s with'
                          ' %(image)s'), {'instance': instance.name,
                                          'image': instance.image_ref})
@@ -388,9 +361,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_destroy for instance', instance=instance)
         try:
-            if not self.container_defined(instance_name, instance):
-                return
-
             LOG.info(_LI('Destroying instance %(instance)s with'
                          ' %(image)s'), {'instance': instance.name,
                                          'image': instance.image_ref})
@@ -425,10 +395,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_paused called for instance', instance=instance)
         try:
-            if not self.container_defined(instance_name, instance):
-                msg = _('Instance is not found %s') % instance_name
-                raise exception.InstanceNotFound(msg)
-
             LOG.info(_LI('Pausing instance %(instance)s with'
                          ' %(image)s'), {'instance': instance_name,
                                          'image': instance.image_ref})
@@ -463,10 +429,6 @@ class LXDAPISession(object):
         """
         LOG.debug('container_unpause called for instance', instance=instance)
         try:
-            if not self.container_defined(instance_name, instance):
-                msg = _('Instance is not found %s') % instance_name
-                raise exception.InstanceNotFound(msg)
-
             LOG.info(_LI('Unpausing instance %(instance)s with'
                          ' %(image)s'), {'instance': instance.name,
                                          'image': instance.image_ref})

--- a/nova/virt/lxd/session.py
+++ b/nova/virt/lxd/session.py
@@ -19,17 +19,14 @@ from nova import context as nova_context
 from nova import exception
 from nova import i18n
 from nova import rpc
-from nova import utils
 from nova.compute import power_state
 
-from oslo_concurrency import processutils
 from oslo_log import log as logging
 from oslo_service import loopingcall
 from oslo_utils import excutils
 
 from pylxd.deprecated import api
 from pylxd.deprecated import exceptions as lxd_exceptions
-import six
 
 from nova.virt.lxd import constants
 
@@ -39,6 +36,7 @@ _LI = i18n._LI
 
 CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
+
 
 class LXDAPISession(object):
     """The session to invoke the LXD API session."""

--- a/nova/virt/lxd/utils.py
+++ b/nova/virt/lxd/utils.py
@@ -41,14 +41,6 @@ class LXDContainerDirectories(object):
         return os.path.join(self.base_dir,
                             '%s-manifest.tar' % image_meta.id)
 
-    def get_container_metadata(self, image_meta):
-        return os.path.join(self.base_dir,
-                            '%s-lxd.tar.xz' % image_meta.id)
-
-    def get_container_rootfsImg(self, image_meta):
-        return os.path.join(self.base_dir,
-                            '%s-root.tar.gz' % image_meta.id)
-
     def get_container_configdrive(self, instance):
         return os.path.join(CONF.instances_path,
                             instance,
@@ -70,24 +62,7 @@ class LXDContainerDirectories(object):
                             'rootfs')
 
     def get_container_rescue(self, instance):
-        if self.is_lvm(instance):
-            return os.path.join(CONF.lxd.root_dir,
-                                'containers',
-                                instance)
-        else:
-            return os.path.join(CONF.lxd.root_dir,
-                                'containers',
-                                instance,
-                                'rootfs')
-
-    def get_container_lvm(self, instance):
-        return '%s/%s.lv' % (self.get_container_dir(instance),
-                             instance)
-
-    def is_lvm(self, instance):
-        try:
-            if os.path.exists(os.readlink(
-                self.get_container_lvm(instance))):
-                return True
-        except Exception:
-            return False
+        return os.path.join(CONF.lxd.root_dir,
+                            'containers',
+                            instance,
+                            'rootfs')


### PR DESCRIPTION
Remove code that is no longer needed, used, and just plain ugly.

- Remove dead code specifically mount/umounting filesy stems. This is no longer used.
- Remove old directory detection that is no longer used or needed.
- Remove container_defined from where it is "overkill". This was done in preparation for pylxd 2.0 since it is handled in a different way. Also update unit tests to reflect this change.